### PR TITLE
In Apple Camera Manager implementation, replace deprecated AVCaptureD…

### DIFF
--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -18,6 +18,11 @@
 
 		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">10.3.4</SupportedOSPlatformVersion>
+
+	</PropertyGroup>
+	<PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+      <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/BigIslandBarcode/Platforms/iOS/AppDelegate.cs
+++ b/BigIslandBarcode/Platforms/iOS/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using Foundation;
 using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
 
 namespace BigIslandBarcode
 {

--- a/ZXing.Net.MAUI/Apple/CameraManager.apple.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.apple.cs
@@ -106,23 +106,18 @@ namespace ZXing.Net.Maui
 					captureDevice = null;
 				}
 
-				var devices = AVCaptureDevice.DevicesWithMediaType(AVMediaTypes.Video.ToString());
-				foreach (var device in devices)
-				{
-					if (CameraLocation == CameraLocation.Front &&
-						device.Position == AVCaptureDevicePosition.Front)
-					{
-						captureDevice = device;
-						break;
-					}
-					else if (CameraLocation == CameraLocation.Rear && device.Position == AVCaptureDevicePosition.Back)
-					{
-						captureDevice = device;
-						break;
-					}
+				if (CameraLocation == CameraLocation.Front)
+                {
+					using var frontCameras =  AVCaptureDeviceDiscoverySession.Create(new[] { AVCaptureDeviceType.BuiltInDualCamera, AVCaptureDeviceType.BuiltInDualWideCamera, AVCaptureDeviceType.BuiltInDuoCamera, AVCaptureDeviceType.BuiltInLiDarDepthCamera, AVCaptureDeviceType.BuiltInMicrophone, AVCaptureDeviceType.BuiltInTelephotoCamera, AVCaptureDeviceType.BuiltInTripleCamera, AVCaptureDeviceType.BuiltInTrueDepthCamera, AVCaptureDeviceType.BuiltInUltraWideCamera, AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.ExternalUnknown }, AVMediaTypes.Video, AVCaptureDevicePosition.Front);
+					captureDevice = frontCameras?.Devices?.FirstOrDefault();
+				}
+				else if (CameraLocation == CameraLocation.Rear)
+                {
+					using var backCameras = AVCaptureDeviceDiscoverySession.Create(new[] { AVCaptureDeviceType.BuiltInDualCamera, AVCaptureDeviceType.BuiltInDualWideCamera, AVCaptureDeviceType.BuiltInDuoCamera, AVCaptureDeviceType.BuiltInLiDarDepthCamera, AVCaptureDeviceType.BuiltInMicrophone, AVCaptureDeviceType.BuiltInTelephotoCamera, AVCaptureDeviceType.BuiltInTripleCamera, AVCaptureDeviceType.BuiltInTrueDepthCamera, AVCaptureDeviceType.BuiltInUltraWideCamera, AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.ExternalUnknown }, AVMediaTypes.Video, AVCaptureDevicePosition.Back);
+					captureDevice = backCameras?.Devices?.FirstOrDefault();
 				}
 
-				if (captureDevice == null)
+                if (captureDevice == null)
 					captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
 
 				captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
@@ -143,7 +138,11 @@ namespace ZXing.Net.Maui
 		public void UpdateTorch(bool on)
 		{
 			if (captureDevice != null && captureDevice.HasTorch && captureDevice.TorchAvailable)
+            {
+				captureDevice.LockForConfiguration(out NSError error);
 				captureDevice.TorchMode = on ? AVCaptureTorchMode.On : AVCaptureTorchMode.Off;
+				captureDevice.UnlockForConfiguration();
+            }
 		}
 
 		public void Focus(Microsoft.Maui.Graphics.Point point)

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -21,6 +21,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!--<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>-->
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+      <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
     <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.0.2.4" />
     <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.0.2.4" />


### PR DESCRIPTION
…evice.DevicesWithMediaType call with AVCaptureDeviceDiscoverSession calls & add Lock/UnlockForConfigration calls to fix torch not working + misc changes to get library and sample app working on iOS.